### PR TITLE
Bugfix [terraform] associate_public_ip_address  (#43)

### DIFF
--- a/deploy/terraform/modules/proxy/rpc_proxy.tf
+++ b/deploy/terraform/modules/proxy/rpc_proxy.tf
@@ -8,9 +8,6 @@ resource "aws_instance" "rpc_proxy" {
   ]
   subnet_id = "${var.subnet_id}"
 
-  /* Superceded by elastic IP resource */
-  associate_public_ip_address = false
-
   tags {
     Name = "dev-rpc-proxy"
   }


### PR DESCRIPTION
Removing the explicit setting of this parameter as AWS flips it to `true` once the elastic IP is assigned, leaving the state inconsistent with our local tfstate file.