### PR TITLE
Minor bugfix for share state / workspaces when used with AWS credentials profiles

### DIFF
--- a/deploy/terraform/variables-example.sh
+++ b/deploy/terraform/variables-example.sh
@@ -7,3 +7,4 @@ export TF_VAR_dns_name="rpc.example.com"
 # probably okay to keep these in here
 export TF_VAR_ami_map='{ us-west-2 = "ami-79873901", us-east-1 = "ami-b374d5a5", us-east-2 = "ami-82f4dae7" }'
 export SECRETS_PATH="$HOME/src/secrets"
+export AWS_PROFILE="$TF_VAR_shared_credentials_profile"


### PR DESCRIPTION
Terraform shared state and workspaces both seem to require having the… AWS credentials profile set in both places.